### PR TITLE
Plugin Check - Fix #2

### DIFF
--- a/includes/class-wc-arkpay-thankyou-redirect.php
+++ b/includes/class-wc-arkpay-thankyou-redirect.php
@@ -13,8 +13,8 @@ function thankyou_redirect_page() {
         global $wpdb;
 
         $table_name = $wpdb->prefix . 'arkpay_draft_order';
-        $transaction_id = $_GET['arkpayTransactionId'];
-        $results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM %s WHERE transaction_id=%s", $table_name, $transaction_id ) );
+        $transaction_id = sanitize_text_field( $_GET['arkpayTransactionId'] );
+        $results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table_name WHERE transaction_id=%s", $transaction_id ) );
         if ( !empty( $results ) ) {
             foreach ( $results as $row ) {
                 $order_transaction_id   = $row->transaction_id;

--- a/includes/class-wc-arkpay-webhook-handler.php
+++ b/includes/class-wc-arkpay-webhook-handler.php
@@ -21,7 +21,7 @@ function handle_arkpay_transaction_status_change_webhook() {
 
         $table_name = $wpdb->prefix . 'arkpay_draft_order';
         $transaction_id = $body->id;
-        $results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM %s WHERE transaction_id=%s", $table_name, $transaction_id ) );
+        $results = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table_name WHERE transaction_id=%s", $transaction_id ) );
         if ( !empty( $results ) ) {
             foreach ( $results as $row ) {
                 $draft_transaction_id       = $row->transaction_id;

--- a/includes/class-wc-gateway-arkpay.php
+++ b/includes/class-wc-gateway-arkpay.php
@@ -634,25 +634,22 @@ class WC_Gateway_Arkpay extends WC_Payment_Gateway {
 
         $signature = $this->create_signature( $http_method, $api_uri, wp_json_encode( $body ), $secret_key );
         $headers = array(
-            'Content-Type: ' . 'application/json',
-            'X-Api-Key: ' . $api_key,
-            'Signature: ' . $signature,
+            'Content-Type'  => 'application/json',
+            'X-Api-Key'     => $api_key,
+            'Signature'     => $signature,
         );
 
-        $ch = curl_init( $api_url . $endpoint );
-        curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-        curl_setopt( $ch, CURLOPT_POST, true );
-        curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
-        curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
-
-        $response = curl_exec( $ch );
-
-        if ( curl_errno( $ch ) ) {
-            echo 'Error: ' . curl_error( $ch );
+        $response = wp_remote_post( $api_url . $endpoint, array(
+            'body'    => wp_json_encode( $body ),
+            'headers' => $headers,
+        ) );
+    
+        if ( is_wp_error( $response ) ) {
+            echo 'Error: ' . $response->get_error_message();
+            return false;
         }
-
-        curl_close( $ch );
-        return json_decode( $response );
+    
+        return json_decode( wp_remote_retrieve_body( $response ) );
     }
 
     /**
@@ -724,24 +721,21 @@ class WC_Gateway_Arkpay extends WC_Payment_Gateway {
 
         $signature = $this->create_signature( $http_method, $api_uri, wp_json_encode( $body, JSON_UNESCAPED_SLASHES ), $secret_key );
         $headers = array(
-            'Content-Type: ' . 'application/json',
-            'X-Api-Key: ' . $api_key,
-            'Signature: ' . $signature,
+            'Content-Type'  => 'application/json',
+            'X-Api-Key'     => $api_key,
+            'Signature'     => $signature,
         );
 
-        $ch = curl_init( $api_url . $endpoint );
-        curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-        curl_setopt( $ch, CURLOPT_POST, true );
-        curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
-        curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
-
-        $response = curl_exec( $ch );
-
-        if ( curl_errno( $ch ) ) {
-            echo 'Error: ' . curl_error( $ch );
+        $response = wp_remote_post( $api_url . $endpoint, array(
+            'body'    => wp_json_encode( $body ),
+            'headers' => $headers,
+        ) );
+    
+        if ( is_wp_error( $response ) ) {
+            echo 'Error: ' . $response->get_error_message();
+            return false;
         }
-        
-        curl_close( $ch );
-        return json_decode( $response );
+    
+        return json_decode( wp_remote_retrieve_body( $response ) );
     }
 }


### PR DESCRIPTION
 - Stable tag does not match the plugin version. The Stable Tag in your readme.txt file does not match the version in your main plugin file. - /arkpay-payment/README.txt, line 7
 
- WordPress.DB.PreparedSQL.InterpolatedNotPrepared - /arkpay-payment/includes/class-wc-arkpay-webhook-handler.php, line 24

 - WordPress.DB.PreparedSQL.InterpolatedNotPrepared - /arkpay-payment/includes/class-wc-arkpay-thankyou-redirect.php, line 17
 
 - WordPress.DB.PreparedSQL.InterpolatedNotPrepared - /arkpay-payment/includes/class-wc-gateway-arkpay.php, line 143