### PR TITLE
use $_SERVER instead of getallheaders()

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -95,3 +95,9 @@ Automatic updates should work smoothly, but we still recommend you back up your 
 **ArkPay**
 
 * Fix - Enhanced response for webhook authentication failure.
+
+= 1.0.5 2024-03-01 =
+
+**ArkPay**
+
+* Fix - use $_SERVER instead of getallheaders()

--- a/arkpay.php
+++ b/arkpay.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Arkpay
  * Plugin URI:        https://arkpay.com
  * Description:       The Smartest, Fastest & Most Secure Payment Processor.
- * Version:           1.0.4
+ * Version:           1.0.5
  * Author:            Arkpay
  * Author URI:        https://arkpay.com/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'ARKPAY_VERSION', '1.0.4' );
+define( 'ARKPAY_VERSION', '1.0.5' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
getallheaders() seems to return empty array for some merchants, so we switch to $_SERVER for getting header values